### PR TITLE
Add IntelliJ & VSCode run configuration files for easier launching of example apps

### DIFF
--- a/.run/Book store.run.xml
+++ b/.run/Book store.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Book store" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/example/book_store/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Mobile app.run.xml
+++ b/.run/Mobile app.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Mobile app" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/example/mobile_app/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Simple example.run.xml
+++ b/.run/Simple example.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Simple example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="filePath" value="$PROJECT_DIR$/example/simple_example/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Book store",
+            "type": "dart",
+            "request": "launch",
+            "program": "example/book_store/lib/main.dart"
+        },
+        {
+            "name": "Mobile app",
+            "type": "dart",
+            "request": "launch",
+            "program": "example/mobile_app/lib/main.dart"
+        },
+        {
+            "name": "Simple example",
+            "type": "dart",
+            "request": "launch",
+            "program": "example/simple_example/lib/main.dart"
+        }
+    ]
+  }


### PR DESCRIPTION
Adds the necessary files so that Android Studio/other IntelliJ-based IDEs and VSCode users can just select an example app from a dropdown menu and press the green "run" button.

This makes it easier to quickly run and see how the example projects look like, without having to open them in separate editors or use the command line.

### IntelliJ / Android Studio
![image](https://user-images.githubusercontent.com/13744304/115107627-dd22cc00-9f74-11eb-9c77-bbcf6280c8ee.png)

### VSCode
![image](https://user-images.githubusercontent.com/13744304/115107653-06435c80-9f75-11eb-9370-7651aab9a6ad.png)
