### PR TITLE
Fixed route_data.dart "part of" path

### DIFF
--- a/lib/src/route_data.dart
+++ b/lib/src/route_data.dart
@@ -1,4 +1,4 @@
-part of '../../routemaster.dart';
+part of '../routemaster.dart';
 
 /// Information generated from a specific path (URL).
 ///


### PR DESCRIPTION
I started getting build errors >= routemaster 0.9.0 where it can't find route_data.dart. It appears as though this path got changed to a relative one, but went up one too many directories.