### PR TITLE
docs: udpate readme to use PageStackNavigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ class HomePage extends StatelessWidget {
       body: TabBarView(
         controller: tabPage.controller,
         children: [
-          for (final stack in tabPage.stacks) StackNavigator(stack: stack),
+          for (final stack in tabPage.stacks) PageStackNavigator(stack: stack),
         ],
       ),
     );


### PR DESCRIPTION
Updating README to use `PageStackNavigator` in the tabs section.