### PR TITLE
Implement toString method for RouteHistory to aid debugging

### DIFF
--- a/lib/src/route_history.dart
+++ b/lib/src/route_history.dart
@@ -141,4 +141,14 @@ class RouteHistory {
       );
     }
   }
+
+  @override
+  String toString() {
+    return 'RouteHistory('
+        'index: $_index, '
+        'canGoBack: $canGoBack, '
+        'canGoForward: $canGoForward, '
+        'history: $_history'
+        ')';
+  }
 }


### PR DESCRIPTION
The goal of this PR is to enable:

```dart
print('${Routemaster.of(context).history}');
```

... when trying to debug your navigation stack.