### PR TITLE
Ambiguate WidgetsBinding.instance to prevent warnings in Flutter 3

### DIFF
--- a/example/book_store/test/helpers.dart
+++ b/example/book_store/test/helpers.dart
@@ -34,13 +34,15 @@ Future<void> recordUrlChanges(
 /// Simulates pressing the system back button
 Future<void> invokeSystemBack() {
   // ignore: invalid_use_of_protected_member
-  return WidgetsBinding.instance!.handlePopRoute();
+  return _ambiguate(WidgetsBinding.instance)!.handlePopRoute();
 }
 
 Future<void> setSystemUrl(String url) {
   // ignore: invalid_use_of_protected_member
-  return WidgetsBinding.instance!.handlePushRoute(url);
+  return _ambiguate(WidgetsBinding.instance)!.handlePushRoute(url);
 }
+
+T? _ambiguate<T>(T? value) => value;
 
 /// Allows us to emulate the behavior of a web browser by storing a simple
 /// stack of routes and popping them, reproducing the same behavior as a user

--- a/example/mobile_app/test/helpers.dart
+++ b/example/mobile_app/test/helpers.dart
@@ -31,10 +31,12 @@ Future<void> recordUrlChanges(
 /// Simulates pressing the system back button
 Future<void> invokeSystemBack() {
   // ignore: invalid_use_of_protected_member
-  return WidgetsBinding.instance!.handlePopRoute();
+  return _ambiguate(WidgetsBinding.instance)!.handlePopRoute();
 }
 
 Future<void> setSystemUrl(String url) {
   // ignore: invalid_use_of_protected_member
-  return WidgetsBinding.instance!.handlePushRoute(url);
+  return _ambiguate(WidgetsBinding.instance)!.handlePushRoute(url);
 }
+
+T? _ambiguate<T>(T? value) => value;

--- a/lib/routemaster.dart
+++ b/lib/routemaster.dart
@@ -526,7 +526,7 @@ class RoutemasterDelegate extends RouterDelegate<RouteData>
 
   void _setHasReported(_ReportType reportType) {
     _reported = reportType;
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    _ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) {
       _reported = _ReportType.none;
     });
   }
@@ -570,7 +570,7 @@ class RoutemasterDelegate extends RouterDelegate<RouteData>
 
       if (_isBuilding) {
         // Schedule update
-        WidgetsBinding.instance?.addPostFrameCallback((_) {
+        _ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) {
           _updateCurrentConfiguration(
             requestSource: requestSource,
             isReplacement: isReplacement,
@@ -720,7 +720,7 @@ class RoutemasterDelegate extends RouterDelegate<RouteData>
           notifyListeners();
         }
 
-        WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+        _ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((timeStamp) {
           if (_state.pendingNavigation != null) {
             // Retry navigation
             _navigate(
@@ -766,7 +766,7 @@ class RoutemasterDelegate extends RouterDelegate<RouteData>
     _rebuildRouter(context);
 
     // Already building; schedule rebuild for next frame
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
+    _ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) {
       _updateCurrentConfiguration();
     });
   }
@@ -1206,7 +1206,7 @@ class _RoutemasterStateTrackerState extends State<_RoutemasterStateTracker> {
 
       newDelegate._rebuildRouter(context);
 
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+      _ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((_) {
         // Dispose after this frame to allow child widgets to unsubscribe
         oldDelegate.dispose();
       });
@@ -1462,3 +1462,5 @@ enum _ReportType {
   navigate,
   neglect,
 }
+
+T? _ambiguate<T>(T? value) => value;

--- a/lib/src/pages/page_stack.dart
+++ b/lib/src/pages/page_stack.dart
@@ -45,7 +45,7 @@ class PageStack extends ChangeNotifier {
       },
     ).toList();
 
-    WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+    _ambiguate(WidgetsBinding.instance)!.addPostFrameCallback((timeStamp) {
       // Flushes out any removed pages
       _routeMap = newRouteMap;
     });

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -50,13 +50,15 @@ Future<void> recordUrlChanges(
 /// Simulates pressing the system back button
 Future<void> invokeSystemBack() {
   // ignore: invalid_use_of_protected_member
-  return WidgetsBinding.instance!.handlePopRoute();
+  return _ambiguate(WidgetsBinding.instance)!.handlePopRoute();
 }
 
 Future<void> setSystemUrl(String url) {
   // ignore: invalid_use_of_protected_member
-  return WidgetsBinding.instance!.handlePushRoute(url);
+  return _ambiguate(WidgetsBinding.instance)!.handlePushRoute(url);
 }
+
+T? _ambiguate<T>(T? value) => value;
 
 class MaterialPageOne extends MaterialPage<void> {
   const MaterialPageOne() : super(child: const PageOne());


### PR DESCRIPTION
As of Flutter 3.0, `WidgetsBinding.instance` has transitioned from nullable to non-null. Routemaster depends on this, and as such has started spewing warnings when building your app.

The [Flutter team recommends](https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#:~:text=T%3F%20_ambiguate%3CT%3E(T%3F%20value)%20%3D%3E%20value%3B) "ambiguating" the call to enable your application / library to upgrade to Flutter 3.0 without requiring Flutter 3.0.

I made that change here in this PR. I opted to create the helper function where needed.

This has been requested here:
https://github.com/tomgilder/routemaster/issues/278

FYI @tomgilder 