### PR TITLE
fix onUnknownRoute exception on back button in web

### DIFF
--- a/lib/src/route_data.dart
+++ b/lib/src/route_data.dart
@@ -163,7 +163,7 @@ class RouteData {
         requestSource: RequestSource.values.firstWhere(
           (source) => source.toString() == requestSource,
         ),
-        pathTemplate: state['pathTemplate'] as String,
+        pathTemplate: state['pathTemplate'] as String?,
         pathParameters: (state['pathParameters'] as Map<String, dynamic>)
             .cast<String, String>(),
         historyIndex: state['historyIndex'] as int?,


### PR DESCRIPTION
This PR fixes null-parameter exception in case of using onUnknownRoute.

pathTemplate could be null if onUnknownRoute is matched, but null is not accepted in fromRouteInformation https://github.com/tomgilder/routemaster/blob/main/lib/src/route_data.dart#L166

To generate an exception:
1. add onUnknownRoute handler (```onUnknownRoute: (path) { return MaterialPage(child: ProfilePage()); },``` for simple_example)
2. visit onUnknownRoute handled page and any next page
3. press back button in web-browser to return to onUnknownRoute handled page

> The following TypeErrorImpl was thrown while dispatching notifications for PlatformRouteInformationProvider:
> Expected a value of type 'String', but got one of type 'Null'
> packages/routemaster/src/route_data.dart 166:45 fromRouteInformation