### PR TITLE
Handle didUpdateWidget for _StackNavigator when using a global key

### DIFF
--- a/lib/routemaster.dart
+++ b/lib/routemaster.dart
@@ -1431,15 +1431,26 @@ class _StackNavigator extends Navigator {
 }
 
 class _StackNavigatorState extends NavigatorState {
+  PageStack get _stack => (widget as _StackNavigator).stack;
+
   @override
   void initState() {
     super.initState();
-    (widget as _StackNavigator).stack._attachedNavigator = this;
+    _stack._attachedNavigator = this;
+  }
+
+  @override
+  void didUpdateWidget(covariant Navigator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget is _StackNavigator && oldWidget.stack != _stack) {
+      oldWidget.stack._attachedNavigator = null;
+      _stack._attachedNavigator = this;
+    }
   }
 
   @override
   void dispose() {
-    (widget as _StackNavigator).stack._attachedNavigator = null;
+    _stack._attachedNavigator = null;
     super.dispose();
   }
 }


### PR DESCRIPTION
# Problem

We found a bug where using a `GlobalKey` for the `PageStackNavigator.navigatorKey` causes the internal `_StackNavigator` to fail to re-assign itself to the internal page stack. This issue presented itself as the Android back button failing to close non-routemaster routes (like a bottom sheet) and instead just closing the entire app.

Inside the `PageStackNavigatorState`, any time the `PageStack` changes, it'll invoke a function that recreates the `_StackNavigator` widget. Without a key, this would cause the navigator widget to run `initState`, thus setting itself on the `PageStack`. However, with a key, the state object is re-used, so `initState` (and `dispose`) are never called.

This is problematic because if you provide a navigator key for hooking into the navigator throughout your app, the `PageStack` can change but the `_StackNavigator`'s state functions are never called and thus `pop()` calls for non-routemaster routes will ultimately return `false`, causing the app to close.

# Solution

To solve this, all we need to do is override `_StackNavigatorState.didUpdateWidget` and handle the scenario of the internal stack changing -- if it changes, then drop the old navigator reference and add a new navigator reference to the new page stack.

FYI @tomgilder 