### PR TITLE
Update nested branch collection dependency to 1.17 and remove List extension "elementAtOrNull"

### DIFF
--- a/lib/src/widget_navigator.dart
+++ b/lib/src/widget_navigator.dart
@@ -277,9 +277,3 @@ mixin RouteDataPage<T> on Page<T> {
   RouteData? _routeData;
   RouteData get routeData => _routeData!;
 }
-
-extension _NullListX<T> on List<T> {
-  T? elementAtOrNull(int index) {
-    return index < 0 || index >= length ? null : this[index];
-  }
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   path: ^1.8.0
-  collection: ^1.15.0
+  collection: ^1.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When updating to the recent Flutter stable release `3.7.0`, the SDK now requires package `collection: ^1.17.0`. Routemaster currently depends on `collection: ^1.15.0`. The updated collection package now includes a `List` extension method for `elementAtOrNull` that  conflicts with the similar method defined in  the `nested` branch `widget_navigator.dart`.

This PR updates the nested branch collection dependency to 1.17 and removes the conflicting implementation of `elementAtOrNull` from "widget_navigator.dart".

BTW, we are successfully using the `nested` branch since it supports routing to our "nested" editing screens from our underlying list views. We would love to see the nested branch's functionality merged into the main branch. I did try to merge the recent main branch updates into the nested branch. The main conflict appears to be the main branch `tab_page.dart` file being renamed to `tab_pages.dart` in the nested branch.