### PR TITLE
Prevent from calling elementAtOrNull with a negative index

### DIFF
--- a/lib/src/widget_navigator.dart
+++ b/lib/src/widget_navigator.dart
@@ -185,7 +185,7 @@ class _WidgetStackNavigatorState extends State<_WidgetStackNavigator> {
     for (var i = 0; i < maxIndex; i++) {
       final newRoute = newRoutes.elementAtOrNull(i);
       final oldRoute = oldRoutes.elementAtOrNull(i);
-      final previousRoute = oldRoutes.elementAtOrNull(i - 1);
+      final previousRoute = i > 0 ? oldRoutes.elementAtOrNull(i - 1) : null;
 
       if (oldRoute == null && newRoute != null) {
         // Page was pushed


### PR DESCRIPTION
The implementation of `elementAtOrNull` from `collection` (1.17.0) is slightly different from the one that existed in `routemaster`'s codebase, since it throws a `RangeError` in the case of a negative index.

This PR retains the usage of `elementAtOrNull` from the `collection` package, but it prevents from using it with a negative index.