### PR TITLE
Fix publish workflow: add id-token permission

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,8 +3,10 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to the publish workflow, required by `dart-lang/setup-dart` for OIDC authentication with pub.dev.

## Test plan
- Merge this PR, then delete and recreate the `v1.1.0` release to re-trigger the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI publishing workflow to grant the workflow an OIDC write permission for secure token-based authentication.
  * Tightened tag filtering for release triggers to only match explicit semantic version patterns (e.g., major.minor.patch).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->