### PR TITLE
Fix build on Flutter 3.44+ and release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.1
+
+* Fixed build error on Flutter 3.44+ where `CupertinoPageTransitionsBuilder`
+  moved from `package:flutter/material.dart` to `package:flutter/cupertino.dart`.
+
 # 1.1.0
 
 * **Breaking:** Minimum Dart SDK raised to 3.10, minimum Flutter raised to 3.38.1.

--- a/lib/src/pages/transition_page.dart
+++ b/lib/src/pages/transition_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 /// A transition for a page pop or push animation.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: routemaster
 description: Easy-to-use Flutter router for web, mobile and desktop. URL-based routing, simple navigation of tabs and nested routes.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/tomgilder/routemaster
 
 environment:


### PR DESCRIPTION
## Summary
- Flutter 3.44 [moved `CupertinoPageTransitionsBuilder`](https://docs.flutter.dev/release/breaking-changes/decouple-page-transition-builders) from `package:flutter/material.dart` to `package:flutter/cupertino.dart`, breaking the build. Importing both keeps compatibility with all supported Flutter versions (no constraint bump needed).
- Bumps version to 1.1.1 and adds a CHANGELOG entry.

## Test plan
- [x] `flutter analyze lib/` clean
- [x] `flutter test` — all 236 tests pass on Flutter 3.44.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build errors on Flutter 3.44+ by resolving SDK compatibility issues.

* **Documentation**
  * Updated CHANGELOG documenting version 1.1.1 release and compatibility improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomgilder/routemaster/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->